### PR TITLE
Fix the build: pin nightly-2022-11-02, repair CI, fix onboarding docs

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,6 +1,7 @@
 on:
   push:
-    branch: ["master"]
+    branches: ["master", "fix/build-and-onboarding"]
+  workflow_dispatch:
 
 name: Publish to crates.io
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,52 +1,54 @@
+name: Build the client
+
 on:
   push:
     branches: ["master", "fix/build-and-onboarding"]
+  pull_request:
   workflow_dispatch:
 
-name: Publish to crates.io
-
-env:
-  CRATES_DEPLOY: false
-
 jobs:
-  build_and_test:
+  build:
     name: Build the client
-    runs-on: ubuntu-latest
-    environment: dev
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Install Nightly toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev libudev-dev \
+            zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+          toolchain: nightly-2022-11-02
 
-      - run: rustup toolchain list
-      - uses: actions-rs/cargo@v1
+      - name: Cargo build cache
+        uses: actions/cache@v4
         with:
-          command: build
-          args: --release --all-features
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-  check_and_publish:
-    name: Check semver and publish to crates.io
-    runs-on: ubuntu-latest
-    environment: dev
+      - name: Build release
+        run: cargo build --release --all-features
+
+  # Publishing to crates.io is a maintainer action and is intentionally
+  # disabled here; kept for reference.
+  publish:
+    name: Publish to crates.io (disabled)
+    if: false
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install Nightly toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-
-      - name: Publish to crates.io
-        if: "contains(${{ env.CRATES_DEPLOY }},'true')"
+          toolchain: nightly-2022-11-02
+      - name: Publish
         run: cargo publish -p tinydancer --token ${CRATES_TOKEN} --no-verify
         env:
-          CRATES_DEPLOY: ${{ secrets.CRATES_DEPLOY }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Note: For Windows download rustup from this [link](https://forge.rust-lang.org/infra/other-installation-methods.html#other-ways-to-install-rustup)
 
 **Configure Toolchain**
+
+This repo pins the required Rust toolchain in `rust-toolchain.toml`
+(`nightly-2022-11-02`). `rustup` installs and selects it automatically on the
+first `cargo` invocation — no manual `rustup default` needed.
+
+The pin is required: `tinydancer` uses nightly-only feature gates
+(`async_closure`, `mutex_unlock`) that newer nightlies have removed, so a current
+toolchain will not compile it.
+
+**Linux system dependencies** (Ubuntu/Debian)
 ```
-rustup default nightly
+sudo apt-get install -y build-essential pkg-config libssl-dev libudev-dev \
+  zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
 ```
 
 **Build and Add to Path**
@@ -29,7 +40,7 @@ cargo b -r && cp ./target/release/tinydancer ~/.local/bin/
 ```
 **Or Install Using Cargo**
 ```
-cargo install --git https://github.com/tinydancer-io/half-baked-client tinydancer
+cargo install --git https://github.com/tinydancer-io/tinydancer tinydancer
 ```
 **Confirm Installation**
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-11-02"

--- a/tinydancer/Cargo.toml
+++ b/tinydancer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinydancer"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 default-run = "tinydancer"
 authors = ["Anoushk Kharangate <kharangateanoushk04@email.com>","Harsh Patel <hp80738@gmail.com>"]


### PR DESCRIPTION
## Summary

The project currently fails to build for everyone on a modern toolchain
(see #35, #36, #37). This PR revives the build and fixes developer onboarding.

**Root cause:** the crate relies on nightly-only feature gates
(`#![feature(async_closure)]`, `#![feature(mutex_unlock)]` in
`tinydancer/src/main.rs`) and locked, era-specific dependencies, but nothing pins
a compatible toolchain. A current nightly can't compile the locked
`proc-macro2 1.0.51` (`unknown feature proc_macro_span_shrink`) and has removed
`mutex_unlock` entirely, so the build dies before it starts. CI made this worse
by installing no system dependencies and using archived `actions-rs/*` actions.

## Changes

- **Add `rust-toolchain.toml`** pinning `nightly-2022-11-02` — the same nightly the
  `diet-rpc-validator` Solana fork (which this crate builds against) uses in its
  `ci/rust-version.sh`. `rustup` now selects the correct compiler automatically.
- **Repair `.github/workflows/crates.yml`:** install the required system deps
  (`protobuf-compiler`, `libudev-dev`, `libssl-dev`, `clang`, `cmake`, …), pin the
  toolchain, move to `ubuntu-22.04`, modernize to `actions/checkout@v4` +
  `dtolnay/rust-toolchain`, fix the malformed `branch:` trigger (→ `branches:`),
  add `pull_request` / `workflow_dispatch`, and disable the crates.io publish job
  (a maintainer-only action).
- **README:** fix the `cargo install` command (the old `half-baked-client` repo now
  redirects), document the pinned toolchain, and list the Linux system deps.
- **Bump** `tinydancer` to `0.0.9`.

## Verification

Built cleanly on GitHub Actions (Ubuntu, `nightly-2022-11-02`):

- Before (fails on `proc-macro2`): https://github.com/jenish-25/tinydancer/actions/runs/28919854760
- After (green, full release build): https://github.com/jenish-25/tinydancer/actions/runs/28921014517

Closes #35, #36, #37.
